### PR TITLE
Fix SerialRunner fails to import TestRunner base class issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
-const TestRunner = require('jest-runner')
+let TestRunner = require('jest-runner')
+if (TestRunner.default) {
+  TestRunner = TestRunner.default
+}
 
 class SerialRunner extends TestRunner {
   constructor(...attr) {


### PR DESCRIPTION
Fix #16
No need to restrict `jest-runner`'s verson